### PR TITLE
Add composite observers to minimize configuration complexity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Version 5.0.0
+
+## Bugfixes
+
+* None
+
+## Features
+
+* Add composite observers to minimize configuration complexity
+* Switch to latest techdivision/import 7.0.* version as dependency
+* Make Actions and ActionInterfaces deprecated, replace DI configuration with GenericAction + GenericIdentifierAction
+
 # Version 4.0.0
 
 ## Bugfixes

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "OSL-3.0",
     "require": {
         "php": ">=5.6.0",
-        "techdivision/import": "6.0.*"
+        "techdivision/import": "7.0.*"
     },
     "require-dev": {
         "doctrine/dbal": "2.5.*",

--- a/etc/techdivision-import.json
+++ b/etc/techdivision-import.json
@@ -96,21 +96,8 @@
               },
               "observers": [
                 {
-                  "pre-import": [
-                    "import_customer.observer.pre.load.entity.id",
-                    "import_customer.observer.clear.customer"
-                  ]
-                },
-                {
                   "import": [
-                    "import_customer.observer.customer",
-                    "import_customer.observer.customer.attribute",
-                    "import_customer_address.observer.export.customer.address"
-                  ]
-                },
-                {
-                  "post-import": [
-                    "import_customer.observer.clean.up"
+                    "import_customer.observer.composite.replace"
                   ]
                 }
               ]
@@ -124,15 +111,7 @@
               "observers": [
                 {
                   "import": [
-                    "import_customer_address.observer.customer.address",
-                    "import_customer_address.observer.customer.address.attribute",
-                    "import_customer_address.observer.default.billing.address",
-                    "import_customer_address.observer.default.shipping.address"
-                  ]
-                },
-                {
-                  "post-import": [
-                    "import_customer_address.observer.clean.up"
+                    "import_customer.observer.composite.address.replace"
                   ]
                 }
               ]
@@ -173,14 +152,7 @@
               "observers": [
                 {
                   "import": [
-                    "import_customer.observer.customer",
-                    "import_customer.observer.customer.attribute.update",
-                    "import_customer_address.observer.export.customer.address"
-                  ]
-                },
-                {
-                  "post-import": [
-                    "import_customer.observer.clean.up"
+                    "import_customer.observer.composite.add_update"
                   ]
                 }
               ]
@@ -194,15 +166,7 @@
               "observers": [
                 {
                   "import": [
-                    "import_customer_address.observer.customer.address",
-                    "import_customer_address.observer.customer.address.attribute.update",
-                    "import_customer_address.observer.default.billing.address",
-                    "import_customer_address.observer.default.shipping.address"
-                  ]
-                },
-                {
-                  "post-import": [
-                    "import_customer_address.observer.clean.up"
+                    "import_customer.observer.composite.address.add_update"
                   ]
                 }
               ]

--- a/src/Actions/CustomerAction.php
+++ b/src/Actions/CustomerAction.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer
  * @link      http://www.techdivision.com
@@ -26,11 +26,12 @@ use TechDivision\Import\Actions\AbstractAction;
 /**
  * An action implementation that provides CRUD functionality for products.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0 use \TechDivision\Import\Actions\GenericIdentifierAction instead
  */
 class CustomerAction extends AbstractAction implements CustomerActionInterface
 {

--- a/src/Actions/CustomerActionInterface.php
+++ b/src/Actions/CustomerActionInterface.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\ActionInterface;
 /**
  * Interface for action implementations that provides CRUD functionality for products.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0
  */
 interface CustomerActionInterface extends ActionInterface
 {

--- a/src/Actions/CustomerDatetimeAction.php
+++ b/src/Actions/CustomerDatetimeAction.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\AbstractAction;
 /**
  * An action implementation that provides CRUD functionality for customer datetime attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0 use \TechDivision\Import\Actions\GenericAction instead
  */
 class CustomerDatetimeAction extends AbstractAction implements CustomerDatetimeActionInterface
 {

--- a/src/Actions/CustomerDatetimeActionInterface.php
+++ b/src/Actions/CustomerDatetimeActionInterface.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\ActionInterface;
 /**
  * Interface for customer datetime action implementations that provides CRUD functionality for customer datetime attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0
  */
 interface CustomerDatetimeActionInterface extends ActionInterface
 {

--- a/src/Actions/CustomerDecimalAction.php
+++ b/src/Actions/CustomerDecimalAction.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\AbstractAction;
 /**
  * An action implementation that provides CRUD functionality for customer decimal attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0 use \TechDivision\Import\Actions\GenericAction instead
  */
 class CustomerDecimalAction extends AbstractAction implements CustomerDecimalActionInterface
 {

--- a/src/Actions/CustomerDecimalActionInterface.php
+++ b/src/Actions/CustomerDecimalActionInterface.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\ActionInterface;
 /**
  * Interface for customer datetime action implementations that provides CRUD functionality for customer decimal attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0
  */
 interface CustomerDecimalActionInterface extends ActionInterface
 {

--- a/src/Actions/CustomerIntAction.php
+++ b/src/Actions/CustomerIntAction.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\AbstractAction;
 /**
  * An action implementation that provides CRUD functionality for customer integer attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0 use \TechDivision\Import\Actions\GenericAction instead
  */
 class CustomerIntAction extends AbstractAction implements CustomerIntActionInterface
 {

--- a/src/Actions/CustomerIntActionInterface.php
+++ b/src/Actions/CustomerIntActionInterface.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\ActionInterface;
 /**
  * Interface for customer datetime action implementations that provides CRUD functionality for customer integer attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0
  */
 interface CustomerIntActionInterface extends ActionInterface
 {

--- a/src/Actions/CustomerTextAction.php
+++ b/src/Actions/CustomerTextAction.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\AbstractAction;
 /**
  * An action implementation that provides CRUD functionality for customer text attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0 use \TechDivision\Import\Actions\GenericAction instead
  */
 class CustomerTextAction extends AbstractAction implements CustomerTextActionInterface
 {

--- a/src/Actions/CustomerTextActionInterface.php
+++ b/src/Actions/CustomerTextActionInterface.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\ActionInterface;
 /**
  * Interface for customer datetime action implementations that provides CRUD functionality for customer text attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0
  */
 interface CustomerTextActionInterface extends ActionInterface
 {

--- a/src/Actions/CustomerVarcharAction.php
+++ b/src/Actions/CustomerVarcharAction.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\AbstractAction;
 /**
  * An action implementation that provides CRUD functionality for customer varchar attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0 use \TechDivision\Import\Actions\GenericAction instead
  */
 class CustomerVarcharAction extends AbstractAction implements CustomerVarcharActionInterface
 {

--- a/src/Actions/CustomerVarcharActionInterface.php
+++ b/src/Actions/CustomerVarcharActionInterface.php
@@ -12,7 +12,7 @@
  * PHP version 5
  *
  * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
+ * @copyright 2019 TechDivision GmbH <info@techdivision.com>
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://github.com/techdivision/import-customer
  * @link      http://www.techdivision.com
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\ActionInterface;
 /**
  * Interface for customer datetime action implementations that provides CRUD functionality for customer varchar attributes.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2018 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-customer
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-customer
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 5.0.0
  */
 interface CustomerVarcharActionInterface extends ActionInterface
 {

--- a/src/Services/CustomerBunchProcessor.php
+++ b/src/Services/CustomerBunchProcessor.php
@@ -20,18 +20,13 @@
 
 namespace TechDivision\Import\Customer\Services;
 
+use TechDivision\Import\Actions\ActionInterface;
 use TechDivision\Import\Connection\ConnectionInterface;
 use TechDivision\Import\Repositories\EavAttributeRepositoryInterface;
+use TechDivision\Import\Repositories\EavEntityTypeRepositoryInterface;
 use TechDivision\Import\Repositories\EavAttributeOptionValueRepositoryInterface;
 use TechDivision\Import\Customer\Assemblers\CustomerAttributeAssemblerInterface;
-use TechDivision\Import\Customer\Actions\CustomerActionInterface;
-use TechDivision\Import\Customer\Actions\CustomerIntActionInterface;
-use TechDivision\Import\Customer\Actions\CustomerTextActionInterface;
-use TechDivision\Import\Customer\Actions\CustomerVarcharActionInterface;
-use TechDivision\Import\Customer\Actions\CustomerDecimalActionInterface;
-use TechDivision\Import\Customer\Actions\CustomerDatetimeActionInterface;
 use TechDivision\Import\Customer\Repositories\CustomerRepositoryInterface;
-use TechDivision\Import\Repositories\EavEntityTypeRepositoryInterface;
 
 /**
  * The customer bunch processor implementation.
@@ -83,42 +78,42 @@ class CustomerBunchProcessor implements CustomerBunchProcessorInterface
     /**
      * The action for customer CRUD methods.
      *
-     * @var \TechDivision\Import\Customer\Actions\CustomerActionInterface
+     * @var \TechDivision\Import\Actions\ActionInterface
      */
     protected $customerAction;
 
     /**
      * The action for customer varchar attribute CRUD methods.
      *
-     * @var \TechDivision\Import\Customer\Actions\CustomerVarcharActionInterface
+     * @var \TechDivision\Import\Actions\ActionInterface
      */
     protected $customerVarcharAction;
 
     /**
      * The action for customer text attribute CRUD methods.
      *
-     * @var \TechDivision\Import\Customer\Actions\CustomerTextActionInterface
+     * @var \TechDivision\Import\Actions\ActionInterface
      */
     protected $customerTextAction;
 
     /**
      * The action for customer int attribute CRUD methods.
      *
-     * @var \TechDivision\Import\Customer\Actions\CustomerIntActionInterface
+     * @var \TechDivision\Import\Actions\ActionInterface
      */
     protected $customerIntAction;
 
     /**
      * The action for customer decimal attribute CRUD methods.
      *
-     * @var \TechDivision\Import\Customer\Actions\CustomerDecimalActionInterface
+     * @var \TechDivision\Import\Actions\ActionInterface
      */
     protected $customerDecimalAction;
 
     /**
      * The action for customer datetime attribute CRUD methods.
      *
-     * @var \TechDivision\Import\Customer\Actions\CustomerDatetimeActionInterface
+     * @var \TechDivision\Import\Actions\ActionInterface
      */
     protected $customerDatetimeAction;
 
@@ -138,12 +133,12 @@ class CustomerBunchProcessor implements CustomerBunchProcessorInterface
      * @param \TechDivision\Import\Repositories\EavAttributeRepositoryInterface            $eavAttributeRepository            The EAV attribute repository to use
      * @param \TechDivision\Import\Customer\Repositories\CustomerRepositoryInterface       $customerRepository                The customer repository to use
      * @param \TechDivision\Import\Repositories\EavEntityTypeRepositoryInterface           $eavEntityTypeRepository           The EAV entity type repository to use
-     * @param \TechDivision\Import\Customer\Actions\CustomerActionInterface                $customerAction                    The customer action to use
-     * @param \TechDivision\Import\Customer\Actions\CustomerDatetimeActionInterface        $customerDatetimeAction            The customer datetime action to use
-     * @param \TechDivision\Import\Customer\Actions\CustomerDecimalActionInterface         $customerDecimalAction             The customer decimal action to use
-     * @param \TechDivision\Import\Customer\Actions\CustomerIntActionInterface             $customerIntAction                 The customer integer action to use
-     * @param \TechDivision\Import\Customer\Actions\CustomerTextActionInterface            $customerTextAction                The customer text action to use
-     * @param \TechDivision\Import\Customer\Actions\CustomerVarcharActionInterface         $customerVarcharAction             The customer varchar action to use
+     * @param \TechDivision\Import\Actions\ActionInterface                                 $customerAction                    The customer action to use
+     * @param \TechDivision\Import\Actions\ActionInterface                                 $customerDatetimeAction            The customer datetime action to use
+     * @param \TechDivision\Import\Actions\ActionInterface                                 $customerDecimalAction             The customer decimal action to use
+     * @param \TechDivision\Import\Actions\ActionInterface                                 $customerIntAction                 The customer integer action to use
+     * @param \TechDivision\Import\Actions\ActionInterface                                 $customerTextAction                The customer text action to use
+     * @param \TechDivision\Import\Actions\ActionInterface                                 $customerVarcharAction             The customer varchar action to use
      */
     public function __construct(
         ConnectionInterface $connection,
@@ -152,12 +147,12 @@ class CustomerBunchProcessor implements CustomerBunchProcessorInterface
         EavAttributeRepositoryInterface $eavAttributeRepository,
         CustomerRepositoryInterface $customerRepository,
         EavEntityTypeRepositoryInterface $eavEntityTypeRepository,
-        CustomerActionInterface $customerAction,
-        CustomerDatetimeActionInterface $customerDatetimeAction,
-        CustomerDecimalActionInterface $customerDecimalAction,
-        CustomerIntActionInterface $customerIntAction,
-        CustomerTextActionInterface $customerTextAction,
-        CustomerVarcharActionInterface $customerVarcharAction
+        ActionInterface $customerAction,
+        ActionInterface $customerDatetimeAction,
+        ActionInterface $customerDecimalAction,
+        ActionInterface $customerIntAction,
+        ActionInterface $customerTextAction,
+        ActionInterface $customerVarcharAction
     ) {
         $this->setConnection($connection);
         $this->setCustomerAttributeAssembler($customerAttributeAssembler);
@@ -263,11 +258,11 @@ class CustomerBunchProcessor implements CustomerBunchProcessorInterface
     /**
      * Set's the action with the customer CRUD methods.
      *
-     * @param \TechDivision\Import\Customer\Actions\CustomerActionInterface $customerAction The action with the customer CRUD methods
+     * @param \TechDivision\Import\Actions\ActionInterface $customerAction The action with the customer CRUD methods
      *
      * @return void
      */
-    public function setCustomerAction(CustomerActionInterface $customerAction)
+    public function setCustomerAction(ActionInterface $customerAction)
     {
         $this->customerAction = $customerAction;
     }
@@ -275,7 +270,7 @@ class CustomerBunchProcessor implements CustomerBunchProcessorInterface
     /**
      * Return's the action with the customer CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Actions\CustomerActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerAction()
     {
@@ -285,11 +280,11 @@ class CustomerBunchProcessor implements CustomerBunchProcessorInterface
     /**
      * Set's the action with the customer varchar attribute CRUD methods.
      *
-     * @param \TechDivision\Import\Customer\Actions\CustomerVarcharActionInterface $customerVarcharAction The action with the customer varchar attriute CRUD methods
+     * @param \TechDivision\Import\Actions\ActionInterface $customerVarcharAction The action with the customer varchar attriute CRUD methods
      *
      * @return void
      */
-    public function setCustomerVarcharAction(CustomerVarcharActionInterface $customerVarcharAction)
+    public function setCustomerVarcharAction(ActionInterface $customerVarcharAction)
     {
         $this->customerVarcharAction = $customerVarcharAction;
     }
@@ -297,7 +292,7 @@ class CustomerBunchProcessor implements CustomerBunchProcessorInterface
     /**
      * Return's the action with the customer varchar attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Actions\CustomerVarcharActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerVarcharAction()
     {
@@ -307,11 +302,11 @@ class CustomerBunchProcessor implements CustomerBunchProcessorInterface
     /**
      * Set's the action with the customer text attribute CRUD methods.
      *
-     * @param \TechDivision\Import\Customer\Actions\CustomerTextActionInterface $customerTextAction The action with the customer text attriute CRUD methods
+     * @param \TechDivision\Import\Actions\ActionInterface $customerTextAction The action with the customer text attriute CRUD methods
      *
      * @return void
      */
-    public function setCustomerTextAction(CustomerTextActionInterface $customerTextAction)
+    public function setCustomerTextAction(ActionInterface $customerTextAction)
     {
         $this->customerTextAction = $customerTextAction;
     }
@@ -319,7 +314,7 @@ class CustomerBunchProcessor implements CustomerBunchProcessorInterface
     /**
      * Return's the action with the customer text attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Actions\CustomerTextActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerTextAction()
     {
@@ -329,11 +324,11 @@ class CustomerBunchProcessor implements CustomerBunchProcessorInterface
     /**
      * Set's the action with the customer int attribute CRUD methods.
      *
-     * @param \TechDivision\Import\Customer\Actions\CustomerIntActionInterface $customerIntAction The action with the customer int attriute CRUD methods
+     * @param \TechDivision\Import\Actions\ActionInterface $customerIntAction The action with the customer int attriute CRUD methods
      *
      * @return void
      */
-    public function setCustomerIntAction(CustomerIntActionInterface $customerIntAction)
+    public function setCustomerIntAction(ActionInterface $customerIntAction)
     {
         $this->customerIntAction = $customerIntAction;
     }
@@ -341,7 +336,7 @@ class CustomerBunchProcessor implements CustomerBunchProcessorInterface
     /**
      * Return's the action with the customer int attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Actions\CustomerIntActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerIntAction()
     {
@@ -351,11 +346,11 @@ class CustomerBunchProcessor implements CustomerBunchProcessorInterface
     /**
      * Set's the action with the customer decimal attribute CRUD methods.
      *
-     * @param \TechDivision\Import\Customer\Actions\CustomerDecimalActionInterface $customerDecimalAction The action with the customer decimal attriute CRUD methods
+     * @param \TechDivision\Import\Actions\ActionInterface $customerDecimalAction The action with the customer decimal attriute CRUD methods
      *
      * @return void
      */
-    public function setCustomerDecimalAction(CustomerDecimalActionInterface $customerDecimalAction)
+    public function setCustomerDecimalAction(ActionInterface $customerDecimalAction)
     {
         $this->customerDecimalAction = $customerDecimalAction;
     }
@@ -363,7 +358,7 @@ class CustomerBunchProcessor implements CustomerBunchProcessorInterface
     /**
      * Return's the action with the customer decimal attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Actions\CustomerDecimalActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerDecimalAction()
     {
@@ -373,11 +368,11 @@ class CustomerBunchProcessor implements CustomerBunchProcessorInterface
     /**
      * Set's the action with the customer datetime attribute CRUD methods.
      *
-     * @param \TechDivision\Import\Customer\Actions\CustomerDatetimeActionInterface $customerDatetimeAction The action with the customer datetime attriute CRUD methods
+     * @param \TechDivision\Import\Actions\ActionInterface $customerDatetimeAction The action with the customer datetime attriute CRUD methods
      *
      * @return void
      */
-    public function setCustomerDatetimeAction(CustomerDatetimeActionInterface $customerDatetimeAction)
+    public function setCustomerDatetimeAction(ActionInterface $customerDatetimeAction)
     {
         $this->customerDatetimeAction = $customerDatetimeAction;
     }
@@ -385,7 +380,7 @@ class CustomerBunchProcessor implements CustomerBunchProcessorInterface
     /**
      * Return's the action with the customer datetime attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Actions\CustomerDatetimeActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerDatetimeAction()
     {

--- a/src/Services/CustomerBunchProcessorInterface.php
+++ b/src/Services/CustomerBunchProcessorInterface.php
@@ -44,42 +44,42 @@ interface CustomerBunchProcessorInterface extends CustomerProcessorInterface, Ea
     /**
      * Return's the action with the customer CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Actions\CustomerActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerAction();
 
     /**
      * Return's the action with the customer varchar attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Actions\CustomerVarcharActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerVarcharAction();
 
     /**
      * Return's the action with the customer text attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Actions\CustomerTextActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerTextAction();
 
     /**
      * Return's the action with the customer int attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Actions\CustomerIntActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerIntAction();
 
     /**
      * Return's the action with the customer decimal attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Actions\CustomerDecimalActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerDecimalAction();
 
     /**
      * Return's the action with the customer datetime attribute CRUD methods.
      *
-     * @return \TechDivision\Import\Customer\Actions\CustomerDatetimeActionInterface The action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The action instance
      */
     public function getCustomerDatetimeAction();
 

--- a/symfony/Resources/config/services.xml
+++ b/symfony/Resources/config/services.xml
@@ -104,32 +104,32 @@
             <argument type="service" id="import_customer.repository.sql.statement"/>
         </service>
 
-        <service id="import_customer.action.customer" class="TechDivision\Import\Customer\Actions\CustomerAction">
+        <service id="import_customer.action.customer" class="TechDivision\Import\Actions\GenericIdentifierAction">
             <argument type="service" id="import_customer.action.processor.customer.create"/>
             <argument type="service" id="import_customer.action.processor.customer.update"/>
             <argument type="service" id="import_customer.action.processor.customer.delete"/>
         </service>
-        <service id="import_customer.action.customer.datetime" class="TechDivision\Import\Customer\Actions\CustomerDatetimeAction">
+        <service id="import_customer.action.customer.datetime" class="TechDivision\Import\Actions\GenericAction">
             <argument type="service" id="import_customer.action.processor.customer.datetime.create"/>
             <argument type="service" id="import_customer.action.processor.customer.datetime.update"/>
             <argument type="service" id="import_customer.action.processor.customer.datetime.delete"/>
         </service>
-        <service id="import_customer.action.customer.decimal" class="TechDivision\Import\Customer\Actions\CustomerDecimalAction">
+        <service id="import_customer.action.customer.decimal" class="TechDivision\Import\Actions\GenericAction">
             <argument type="service" id="import_customer.action.processor.customer.decimal.create"/>
             <argument type="service" id="import_customer.action.processor.customer.decimal.update"/>
             <argument type="service" id="import_customer.action.processor.customer.decimal.delete"/>
         </service>
-        <service id="import_customer.action.customer.int" class="TechDivision\Import\Customer\Actions\CustomerIntAction">
+        <service id="import_customer.action.customer.int" class="TechDivision\Import\Actions\GenericAction">
             <argument type="service" id="import_customer.action.processor.customer.int.create"/>
             <argument type="service" id="import_customer.action.processor.customer.int.update"/>
             <argument type="service" id="import_customer.action.processor.customer.int.delete"/>
         </service>
-        <service id="import_customer.action.customer.text" class="TechDivision\Import\Customer\Actions\CustomerTextAction">
+        <service id="import_customer.action.customer.text" class="TechDivision\Import\Actions\GenericAction">
             <argument type="service" id="import_customer.action.processor.customer.text.create"/>
             <argument type="service" id="import_customer.action.processor.customer.text.update"/>
             <argument type="service" id="import_customer.action.processor.customer.text.delete"/>
         </service>
-        <service id="import_customer.action.customer.varchar" class="TechDivision\Import\Customer\Actions\CustomerVarcharAction">
+        <service id="import_customer.action.customer.varchar" class="TechDivision\Import\Actions\GenericAction">
             <argument type="service" id="import_customer.action.processor.customer.varchar.create"/>
             <argument type="service" id="import_customer.action.processor.customer.varchar.update"/>
             <argument type="service" id="import_customer.action.processor.customer.varchar.delete"/>
@@ -175,6 +175,90 @@
         </service>
         <service id="import_customer.observer.clear.customer" class="TechDivision\Import\Customer\Observers\ClearCustomerObserver">
             <argument type="service" id="import_customer.processor.customer.bunch"/>
+        </service>
+
+        <!--
+         | The DI configuration for the composite observers of the customer replace operation.
+         |-->
+        <service id="import_customer.observer.composite.replace" class="TechDivision\Import\Observers\GenericCompositeObserver">
+            <call method="addObserver">
+                <argument id="import_customer.observer.pre.load.entity.id" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer.observer.clear.customer" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer.observer.customer" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer.observer.customer.attribute" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.export.customer.address" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer.observer.clean.up" type="service"/>
+            </call>
+        </service>
+
+        <!--
+         | The DI configuration for the composite observers of the customer address replace operation.
+         |-->
+        <service id="import_customer.observer.composite.address.replace" class="TechDivision\Import\Observers\GenericCompositeObserver">
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.customer.address" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.customer.address.attribute" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.default.billing.address" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.default.shipping.address" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.clean.up" type="service"/>
+            </call>
+        </service>
+
+        <!--
+         | The DI configuration for the composite observers of the customer add-update operation.
+         |-->
+        <service id="import_customer.observer.composite.add_update" class="TechDivision\Import\Observers\GenericCompositeObserver">
+            <call method="addObserver">
+                <argument id="import_customer.observer.customer" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer.observer.customer.attribute.update" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.export.customer.address" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer.observer.clean.up" type="service"/>
+            </call>
+        </service>
+
+        <!--
+         | The DI configuration for the composite observers of the customer address add-update operation.
+         |-->
+        <service id="import_customer.observer.composite.address.add_update" class="TechDivision\Import\Observers\GenericCompositeObserver">
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.customer.address" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.customer.address.attribute.update" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.default.billing.address" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.default.shipping.address" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_customer_address.observer.clean.up" type="service"/>
+            </call>
         </service>
 
         <service id="import_customer.subject.bunch" class="TechDivision\Import\Customer\Subjects\BunchSubject" shared="false">


### PR DESCRIPTION
Switch to latest techdivision/import 7.0.* version as dependency
Make Actions and ActionInterfaces deprecated, replace DI configuration with GenericAction + GenericIdentifierAction